### PR TITLE
Convert getLastReviewToMerge to getFirstApprovalToMerge

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ PR,Commits,Additions,Deletions,Changed Files,Time to First Review,Comments,Parti
 
 - **Time to first review**: The duration from when the pull request was created to when the first review against it was completed.
 - **Feature lead time**: The duration from when the first commit contained in the pull request was created to when the pull request was merged.
-- **Last review to merge**: The duration from when the last pull request review was completed to when the pull request is merged.
+- **First approval to merge**: The duration from when the first approval review is given to when the pull request is merged.
 
 ## Influences
 

--- a/cmd/graphql.go
+++ b/cmd/graphql.go
@@ -8,12 +8,19 @@ type Comments struct {
 	TotalCount int
 }
 
+type Author struct {
+	Login string
+}
+
 type ReviewNodes []struct {
+	Author    Author
 	CreatedAt string
+	State     string
 }
 
 type Reviews struct {
-	Nodes ReviewNodes
+	TotalCount int
+	Nodes      ReviewNodes
 }
 
 type Commit struct {
@@ -41,17 +48,17 @@ type MetricsGQLQuery struct {
 	Search struct {
 		Nodes []struct {
 			PullRequest struct {
-				Additions     int
-				Deletions     int
-				Number        int
-				CreatedAt     string
-				ChangedFiles  int
-				MergedAt      string
-				Participants  Participants
-				Comments      Comments
-				Reviews       Reviews       `graphql:"reviews(first: 1)"`
-				LatestReviews LatestReviews `graphql:"latestReviews(first: 1)"`
-				Commits       Commits       `graphql:"commits(first: 1)"`
+				Author       Author
+				Additions    int
+				Deletions    int
+				Number       int
+				CreatedAt    string
+				ChangedFiles int
+				MergedAt     string
+				Participants Participants
+				Comments     Comments
+				Reviews      Reviews `graphql:"reviews(first: 50, states: [APPROVED, CHANGES_REQUESTED, COMMENTED])"`
+				Commits      Commits `graphql:"commits(first: 1)"`
 			} `graphql:"... on PullRequest"`
 		}
 	} `graphql:"search(query: $query, type: ISSUE, last: 50)"`

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -26,6 +26,9 @@ const (
         "search": {
             "nodes": [
                 {
+                    "author": {
+                        "login": "Batman"
+                    },
                     "additions": 6,
                     "deletions": 3,
                     "number": 5339,
@@ -41,14 +44,11 @@ const (
                     "reviews": {
                         "nodes": [
                             {
-                                "createdAt": "2022-03-21T15:12:52Z"
-                            }
-                        ]
+                                "author": {
+                                    "login": "Joker"
                     },
-                    "latestReviews": {
-                        "nodes": [
-                            {
-                                "createdAt": "2022-03-21T15:12:52Z"
+                                "createdAt": "2022-03-21T15:12:52Z",
+                                "state": "APPROVED"
                             }
                         ]
                     },
@@ -243,10 +243,19 @@ func Test_getFeatureLeadTime_NoCommits(t *testing.T) {
 	st.Assert(t, ui.getFeatureLeadTime("2022-03-21T15:11:09Z", commits), "--")
 }
 
-func Test_getLastReviewToMerge(t *testing.T) {
-	var latestReviews = LatestReviews{
-		Nodes: LatestReviewNodes{
-			{CreatedAt: "2022-03-20T15:11:09Z"},
+func Test_getFirstApprovalToMerge(t *testing.T) {
+	var reviews = Reviews{
+		Nodes: ReviewNodes{
+			{
+				Author:    Author{Login: "Batman"},
+				CreatedAt: "2022-03-19T15:00:09Z",
+				State:     "COMMENTED",
+			},
+			{
+				Author:    Author{Login: "Joker"},
+				CreatedAt: "2022-03-20T15:11:09Z",
+				State:     "APPROVED",
+			},
 		},
 	}
 
@@ -257,7 +266,7 @@ func Test_getLastReviewToMerge(t *testing.T) {
 			WorkdayEndFunc:   WorkdayEnd,
 		},
 	}
-	st.Assert(t, uiWithWeekends.getLastReviewToMerge("2022-03-21T15:11:09Z", latestReviews), "24h0m")
+	st.Assert(t, uiWithWeekends.getFirstApprovalToMerge("Batman", "2022-03-21T15:11:09Z", reviews), "24h0m")
 
 	uiWithoutWeekends := &UI{
 		Calendar: &cal.BusinessCalendar{
@@ -266,14 +275,14 @@ func Test_getLastReviewToMerge(t *testing.T) {
 			WorkdayEndFunc:   WorkdayEnd,
 		},
 	}
-	st.Assert(t, uiWithoutWeekends.getLastReviewToMerge("2022-03-21T15:11:09Z", latestReviews), "15h11m")
+	st.Assert(t, uiWithoutWeekends.getFirstApprovalToMerge("Batman", "2022-03-21T15:11:09Z", reviews), "15h11m")
 }
 
-func Test_getLastReviewToMerge_NoReviews(t *testing.T) {
-	var latestReviews = LatestReviews{
-		Nodes: LatestReviewNodes{},
+func Test_getFirstApprovalToMerge_NoReviews(t *testing.T) {
+	var reviews = Reviews{
+		Nodes: ReviewNodes{},
 	}
 
 	ui := &UI{}
-	st.Assert(t, ui.getLastReviewToMerge("2022-03-21T15:11:09Z", latestReviews), "--")
+	st.Assert(t, ui.getFirstApprovalToMerge("Batman", "2022-03-21T15:11:09Z", reviews), "--")
 }


### PR DESCRIPTION
Instead of recording last review to merge, record the time from first approval to merge.

Fixes https://github.com/hectcastro/gh-metrics/issues/12