### PR TITLE
feat!: make getTimeToFirstReview use ready for review

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ $ gh metrics --owner cli --repo cli
 │ 5423 │       1 │        41 │         8 │             2 │ 1h7m                 │        0 │            2 │ 67h55m            │ --                          │ 66h44m                  │
 │ 5410 │       4 │        10 │        74 │             4 │ 12h45m               │        3 │            4 │ 44h39m            │ 26h47m                      │ 30h41m                  │
 │ 5409 │       2 │       113 │         1 │             3 │ 11h58m               │        0 │            3 │ 24h56m            │ 7h29m                       │ 9m                      │
-│ 5408 │       1 │         3 │         5 │             1 │ 13h25m               │        0 │            2 │ 18h15m            │ --                          │ 4h52m                   │
+│ 5408 │       1 │         3 │         5 │             1 │ 13h15m               │        0 │            2 │ 18h15m            │ --                          │ 4h52m                   │
 │ 5406 │       1 │         1 │         0 │             1 │ 18h5m                │        1 │            4 │ 18h19m            │ --                          │ 14m                     │
-│ 5405 │       1 │         2 │         8 │             1 │ 2h17m                │        0 │            5 │ 19h0m             │ 15h47m                      │ 16h38m                  │
+│ 5405 │       1 │         2 │         8 │             1 │ 2h9m                 │        0 │            5 │ 19h0m             │ 15h47m                      │ 16h38m                  │
 │ 5396 │       1 │        37 │         2 │             2 │ 207h33m              │        0 │            3 │ 207h40m           │ --                          │ 6m                      │
 │ 5390 │       7 │       183 │         0 │             3 │ 65h41m               │        1 │            4 │ 329h11m           │ 23h56m                      │ 4h29m                   │
 │ 5388 │       4 │         8 │         3 │             5 │ 89h0m                │        0 │            4 │ 238h47m           │ 149h47m                     │ 1h39m                   │
-│ 5380 │       5 │        54 │         7 │             3 │ --                   │        1 │            6 │ 282h6m            │ 277h6m                      │ --                      │
-│ 5378 │       2 │        58 │        10 │             9 │ 184h0m               │        0 │            3 │ 285h40m           │ --                          │ 101h36m                 │
-│ 5366 │       6 │       101 │       376 │            12 │ 23h58m               │        1 │            2 │ 234h38m           │ 195h57m                     │ 27m                     │
+│ 5380 │       5 │        54 │         7 │             3 │ 4h58m                │        1 │            6 │ 282h6m            │ 277h6m                      │ --                      │
+│ 5378 │       2 │        58 │        10 │             9 │ 184h0m               │        1 │            4 │ 285h40m           │ --                          │ 101h36m                 │
+│ 5366 │       6 │       101 │       376 │            12 │ 2h8m                 │        1 │            2 │ 234h38m           │ 195h57m                     │ 27m                     │
 └──────┴─────────┴───────────┴───────────┴───────────────┴──────────────────────┴──────────┴──────────────┴───────────────────┴─────────────────────────────┴─────────────────────────┘
 ```
 
@@ -42,7 +42,7 @@ Or, within a more precise window of time:
 
 ```console
 $ gh metrics --owner cli --repo cli --start 2022-03-21 --end 2022-03-22
-┌──────┬─────────┬───────────┬───────────┬───────────────┬──────────────────────┬──────────┬──────────────┬───────────────────┬─────────────────────────────┬─────────────────────────┐
+┌──────┬─────────┬───────────┬───────────┬───────────────┬──────────────────────┌──────┬─────────┬───────────┬───────────┬───────────────┬──────────────────────┬──────────┬──────────────┬───────────────────┬─────────────────────────────┬─────────────────────────┐
 │   PR │ COMMITS │ ADDITIONS │ DELETIONS │ CHANGED FILES │ TIME TO FIRST REVIEW │ COMMENTS │ PARTICIPANTS │ FEATURE LEAD TIME │ FIRST REVIEW TO LAST REVIEW │ FIRST APPROVAL TO MERGE │
 ├──────┼─────────┼───────────┼───────────┼───────────────┼──────────────────────┼──────────┼──────────────┼───────────────────┼─────────────────────────────┼─────────────────────────┤
 │ 5339 │       4 │         6 │         3 │             1 │ 2m                   │        0 │            3 │ 1h12m             │ 59m                         │ 1h9m                    │
@@ -63,7 +63,7 @@ PR,Commits,Additions,Deletions,Changed Files,Time to First Review,Comments,Parti
 
 ## Metric definitions
 
-- **Time to first review**: The duration from when the pull request was created to when the first review against it was completed.
+- **Time to first review**: The duration from when the pull request was created or marked *Ready for review* to when the first review against it was completed.
 - **Feature lead time**: The duration from when the first commit contained in the pull request was created to when the pull request was merged.
 - **First review to last review**: The duration between the first non-author review and the last approving non-author review ([Background](https://github.com/hectcastro/gh-metrics/issues/13)) 
 - **First approval to merge**: The duration from when the first approval review is given to when the pull request is merged.

--- a/cmd/graphql.go
+++ b/cmd/graphql.go
@@ -36,29 +36,36 @@ type Commits struct {
 	Nodes      CommitNodes
 }
 
-type LatestReviewNodes []struct {
+type ReadyForReviewEvent struct {
 	CreatedAt string
 }
 
-type LatestReviews struct {
-	Nodes LatestReviewNodes
+type TimelineItemNodes []struct {
+	ReadyForReviewEvent ReadyForReviewEvent `graphql:"... on ReadyForReviewEvent"`
+}
+
+type TimelineItems struct {
+	TotalCount int
+	Nodes      TimelineItemNodes
 }
 
 type MetricsGQLQuery struct {
 	Search struct {
 		Nodes []struct {
 			PullRequest struct {
-				Author       Author
-				Additions    int
-				Deletions    int
-				Number       int
-				CreatedAt    string
-				ChangedFiles int
-				MergedAt     string
-				Participants Participants
-				Comments     Comments
-				Reviews      Reviews `graphql:"reviews(first: 50, states: [APPROVED, CHANGES_REQUESTED, COMMENTED])"`
-				Commits      Commits `graphql:"commits(first: 1)"`
+				Author        Author
+				Additions     int
+				Deletions     int
+				Number        int
+				CreatedAt     string
+				ChangedFiles  int
+				IsDraft       bool
+				MergedAt      string
+				Participants  Participants
+				Comments      Comments
+				Reviews       Reviews       `graphql:"reviews(first: 50, states: [APPROVED, CHANGES_REQUESTED, COMMENTED])"`
+				Commits       Commits       `graphql:"commits(first: 1)"`
+				TimelineItems TimelineItems `graphql:"timelineItems(first: 1, itemTypes: [READY_FOR_REVIEW_EVENT])"`
 			} `graphql:"... on PullRequest"`
 		}
 	} `graphql:"search(query: $query, type: ISSUE, last: 50)"`


### PR DESCRIPTION
Instead of starting the clock for time to first review when the pull request is created, have it start when the pull request is marked as ready for review. If the pull request was never in a draft state, then use the pull request created timestamp as the start of the clock.

Fixes https://github.com/hectcastro/gh-metrics/issues/8