### PR TITLE
feat: add getFirstReviewToLastReview

### DIFF
--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -125,7 +125,7 @@ func Test_SearchQuery_WithCSV(t *testing.T) {
 		Calendar:   cal.NewBusinessCalendar(),
 	}
 
-	st.Assert(t, strings.Contains(ui.PrintMetrics(), "5339,4,6,3,1,2m,0,3,1h12m,1h9m"), true)
+	st.Assert(t, strings.Contains(ui.PrintMetrics(), "5339,4,6,3,1,2m,0,3,1h12m,--,1h9m"), true)
 }
 
 func Test_subtractTime_WithinWorkday(t *testing.T) {
@@ -241,6 +241,44 @@ func Test_getFeatureLeadTime_NoCommits(t *testing.T) {
 
 	ui := &UI{}
 	st.Assert(t, ui.getFeatureLeadTime("2022-03-21T15:11:09Z", commits), "--")
+}
+
+func Test_getFirstReviewToLastReview(t *testing.T) {
+	var reviews = Reviews{
+		Nodes: ReviewNodes{
+			{
+				Author: Author{
+					Login: "Batman",
+				},
+				CreatedAt: "2022-04-06T15:11:09Z",
+				State:     "COMMENTED",
+			},
+			{
+				Author: Author{
+					Login: "Joker",
+				},
+				CreatedAt: "2022-04-06T16:11:09Z",
+				State:     "CHANGES_REQUESTED",
+			},
+			{
+				Author: Author{
+					Login: "Joker",
+				},
+				CreatedAt: "2022-04-06T17:11:09Z",
+				State:     "APPROVED",
+			},
+		},
+	}
+
+	uiWithWeekends := &UI{
+		Calendar: &cal.BusinessCalendar{
+			WorkdayFunc:      WorkdayAllDays,
+			WorkdayStartFunc: WorkdayStart,
+			WorkdayEndFunc:   WorkdayEnd,
+		},
+	}
+
+	st.Assert(t, uiWithWeekends.getFirstReviewToLastReview("Batman", reviews), "1h0m")
 }
 
 func Test_getFirstApprovalToMerge(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/hectcastro/gh-metrics/issues/13

Adds a new field for getting the time between the first review and the last review (excluding the author's review).

I had to branch off of `hmc/get-first-approval-to-merge` to exclude the author's first review... waiting until https://github.com/hectcastro/gh-metrics/pull/10 is merged to change the base branch back to `main`. 