### PR TITLE
feat: add support for GraphQL response pagination

### DIFF
--- a/cmd/graphql.go
+++ b/cmd/graphql.go
@@ -1,15 +1,20 @@
 package cmd
 
+type PageInfo struct {
+	HasNextPage bool
+	EndCursor   string
+}
+
+type Author struct {
+	Login string
+}
+
 type Participants struct {
 	TotalCount int
 }
 
 type Comments struct {
 	TotalCount int
-}
-
-type Author struct {
-	Login string
 }
 
 type ReviewNodes []struct {
@@ -51,7 +56,8 @@ type TimelineItems struct {
 
 type MetricsGQLQuery struct {
 	Search struct {
-		Nodes []struct {
+		PageInfo PageInfo
+		Nodes    []struct {
 			PullRequest struct {
 				Author        Author
 				Additions     int
@@ -68,5 +74,5 @@ type MetricsGQLQuery struct {
 				TimelineItems TimelineItems `graphql:"timelineItems(first: 1, itemTypes: [READY_FOR_REVIEW_EVENT])"`
 			} `graphql:"... on PullRequest"`
 		}
-	} `graphql:"search(query: $query, type: ISSUE, last: 50)"`
+	} `graphql:"search(query: $query, type: ISSUE, last: $resultCount, after: $afterCursor)"`
 }

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -527,6 +527,54 @@ func Test_getFirstReviewToLastReview_ReviewerReviewCommentLast(t *testing.T) {
 	st.Assert(t, uiWithWeekends.getFirstReviewToLastReview("Batman", reviews), "1h0m")
 }
 
+func Test_getFirstReviewToLastReview_OnlyAuthorReview(t *testing.T) {
+	var reviews = Reviews{
+		Nodes: ReviewNodes{
+			{
+				Author: Author{
+					Login: "Batman",
+				},
+				CreatedAt: "2022-04-06T15:11:09Z",
+				State:     "COMMENTED",
+			},
+		},
+	}
+
+	uiWithWeekends := &UI{
+		Calendar: &cal.BusinessCalendar{
+			WorkdayFunc:      WorkdayAllDays,
+			WorkdayStartFunc: WorkdayStart,
+			WorkdayEndFunc:   WorkdayEnd,
+		},
+	}
+
+	st.Assert(t, uiWithWeekends.getFirstReviewToLastReview("Batman", reviews), DefaultEmptyCell)
+}
+
+func Test_getFirstReviewToLastReview_NoApprovals(t *testing.T) {
+	var reviews = Reviews{
+		Nodes: ReviewNodes{
+			{
+				Author: Author{
+					Login: "Joker",
+				},
+				CreatedAt: "2022-04-06T15:11:09Z",
+				State:     "COMMENTED",
+			},
+		},
+	}
+
+	uiWithWeekends := &UI{
+		Calendar: &cal.BusinessCalendar{
+			WorkdayFunc:      WorkdayAllDays,
+			WorkdayStartFunc: WorkdayStart,
+			WorkdayEndFunc:   WorkdayEnd,
+		},
+	}
+
+	st.Assert(t, uiWithWeekends.getFirstReviewToLastReview("Batman", reviews), DefaultEmptyCell)
+}
+
 func Test_getFirstApprovalToMerge(t *testing.T) {
 	var reviews = Reviews{
 		Nodes: ReviewNodes{


### PR DESCRIPTION
When GraphQL query responses are larger than the default page size (100), use the response cursor to paginate through the pages until all pull requests matching the search query are accounted for.

Fixes #1 