### PR TITLE
feat!: make CSV duration format more compatible with Excel

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Alternatively, instead of the default table output, output can be generated in C
 ```console
 $ gh metrics --owner cli --repo cli --start 2022-03-21 --end 2022-03-22 --csv
 PR,Commits,Additions,Deletions,Changed Files,Time to First Review,Comments,Participants,Feature Lead Time,First to Last Review,First Approval to Merge
-5339,4,6,3,1,2m,0,3,1h12m,59m,1h9m
-5336,1,2,2,2,7m,0,1,2h30m,--,2h24m
-5327,1,1,1,1,41h57m,1,4,65h44m,23h21m,23h36m
+5339,4,6,3,1,00:02,0,3,01:12,00:59,01:09
+5336,1,2,2,2,00:07,0,1,02:30,00:00,02:24
+5327,1,1,1,1,41:57,1,4,65:44,23:21,23:36
 ```
 
 ## Metric definitions

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -204,8 +204,8 @@ func Test_SearchQuery_WithCSV(t *testing.T) {
 
 	have := ui.PrintMetrics()
 
-	st.Assert(t, strings.Contains(have, "5339,1,6,3,1,38h13m,0,3,1h12m,8h0m,6h51m"), true)
-	st.Assert(t, strings.Contains(have, "5340,1,12,6,2,38h13m,0,3,1h12m,8h0m,6h51m"), true)
+	st.Assert(t, strings.Contains(have, "5339,1,6,3,1,38:13,0,3,01:12,08:00,06:51"), true)
+	st.Assert(t, strings.Contains(have, "5340,1,12,6,2,38:13,0,3,01:12,08:00,06:51"), true)
 }
 
 func Test_SearchQuery_WithPagination(t *testing.T) {
@@ -242,8 +242,8 @@ func Test_SearchQuery_WithPagination(t *testing.T) {
 
 	have := ui.printMetricsImpl(1)
 
-	st.Assert(t, strings.Contains(have, "5339,1,6,3,1,38h13m,0,3,1h12m,8h0m,6h51m"), true)
-	st.Assert(t, strings.Contains(have, "5340,1,12,6,2,38h13m,0,3,1h12m,8h0m,6h51m"), true)
+	st.Assert(t, strings.Contains(have, "5339,1,6,3,1,38:13,0,3,01:12,08:00,06:51"), true)
+	st.Assert(t, strings.Contains(have, "5340,1,12,6,2,38:13,0,3,01:12,08:00,06:51"), true)
 }
 
 func Test_subtractTime_WithinWorkday(t *testing.T) {
@@ -282,11 +282,19 @@ func Test_subtractTime_SpanningWeekend(t *testing.T) {
 }
 
 func Test_formatDuration_LessThanMinute(t *testing.T) {
-	st.Assert(t, formatDuration(time.Second*5), DefaultEmptyCell)
+	st.Assert(t, formatDuration(time.Second*5, false), DefaultEmptyCell)
+}
+
+func Test_formatDuration_LessThanMinuteWithCSV(t *testing.T) {
+	st.Assert(t, formatDuration(time.Second*5, true), "00:00")
 }
 
 func Test_formatDuration_MoreThanMinute(t *testing.T) {
-	st.Assert(t, formatDuration(time.Minute*5), "5m")
+	st.Assert(t, formatDuration(time.Minute*5, false), "5m")
+}
+
+func Test_formatDuration_MoreThanMinuteWithCSV(t *testing.T) {
+	st.Assert(t, formatDuration(time.Minute*5, true), "00:05")
 }
 
 func Test_getReadyForReviewOrPrCreatedAt_prCreatedAt(t *testing.T) {


### PR DESCRIPTION
Make durations more compatible with Excel when `--csv` is used. The hope is that this format is better interpreted by Excel such that it can be used with built-in format types.