### PR TITLE
feat: replace owner/repo flags with single '--repo'

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ gh extension install hectcastro/gh-metrics
 Once installed, you can summarize all pull requests for the `cli/cli` repository over the last 10 days:
 
 ```console
-$ gh metrics --owner cli --repo cli
+$ gh metrics --repo cli/cli
 ┌──────┬─────────┬───────────┬───────────┬───────────────┬──────────────────────┬──────────┬──────────────┬───────────────────┬──────────────────────┬─────────────────────────┐
 │   PR │ COMMITS │ ADDITIONS │ DELETIONS │ CHANGED FILES │ TIME TO FIRST REVIEW │ COMMENTS │ PARTICIPANTS │ FEATURE LEAD TIME │ FIRST TO LAST REVIEW │ FIRST APPROVAL TO MERGE │
 ├──────┼─────────┼───────────┼───────────┼───────────────┼──────────────────────┼──────────┼──────────────┼───────────────────┼──────────────────────┼─────────────────────────┤
@@ -32,7 +32,7 @@ $ gh metrics --owner cli --repo cli
 Or, within a more precise window of time:
 
 ```console
-$ gh metrics --owner cli --repo cli --start 2022-03-21 --end 2022-03-22
+$ gh metrics --repo cli/cli --start 2022-03-21 --end 2022-03-22
 ┌──────┬─────────┬───────────┬───────────┬───────────────┬──────────────────────┬──────────┬──────────────┬───────────────────┬──────────────────────┬─────────────────────────┐
 │   PR │ COMMITS │ ADDITIONS │ DELETIONS │ CHANGED FILES │ TIME TO FIRST REVIEW │ COMMENTS │ PARTICIPANTS │ FEATURE LEAD TIME │ FIRST TO LAST REVIEW │ FIRST APPROVAL TO MERGE │
 ├──────┼─────────┼───────────┼───────────┼───────────────┼──────────────────────┼──────────┼──────────────┼───────────────────┼──────────────────────┼─────────────────────────┤
@@ -45,7 +45,7 @@ $ gh metrics --owner cli --repo cli --start 2022-03-21 --end 2022-03-22
 Or, with an additional query filter:
 
 ```console
-$ gh metrics --owner cli --repo cli --start 2022-03-21 --end 2022-03-22 --query "author:josebalius"
+$ gh metrics --repo cli/cli --start 2022-03-21 --end 2022-03-22 --query "author:josebalius"
 ┌──────┬─────────┬───────────┬───────────┬───────────────┬──────────────────────┬──────────┬──────────────┬───────────────────┬──────────────────────┬─────────────────────────┐
 │   PR │ COMMITS │ ADDITIONS │ DELETIONS │ CHANGED FILES │ TIME TO FIRST REVIEW │ COMMENTS │ PARTICIPANTS │ FEATURE LEAD TIME │ FIRST TO LAST REVIEW │ FIRST APPROVAL TO MERGE │
 ├──────┼─────────┼───────────┼───────────┼───────────────┼──────────────────────┼──────────┼──────────────┼───────────────────┼──────────────────────┼─────────────────────────┤
@@ -56,7 +56,7 @@ $ gh metrics --owner cli --repo cli --start 2022-03-21 --end 2022-03-22 --query 
 Alternatively, instead of the default table output, output can be generated in CSV format:
 
 ```console
-$ gh metrics --owner cli --repo cli --start 2022-03-21 --end 2022-03-22 --csv
+$ gh metrics --repo cli/cli --start 2022-03-21 --end 2022-03-22 --csv
 PR,Commits,Additions,Deletions,Changed Files,Time to First Review,Comments,Participants,Feature Lead Time,First to Last Review,First Approval to Merge
 5339,4,6,3,1,00:02,0,3,01:12,00:59,01:09
 5336,1,2,2,2,00:07,0,1,02:30,00:00,02:24

--- a/cmd/ghrepo.go
+++ b/cmd/ghrepo.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/cli/go-gh/pkg/auth"
+)
+
+// GHRepo represents a GitHub repository.
+type GHRepo struct {
+	Owner string
+	Name  string
+	Host  string
+}
+
+// newGHRepo returns a GHRepo configured via the '/'-delimited string it's passed.
+func newGHRepo(name string) (*GHRepo, error) {
+	defaultHost, _ := auth.DefaultHost()
+	nameParts := strings.Split(name, "/")
+
+	switch len(nameParts) {
+	case 2:
+		return &GHRepo{
+			Owner: nameParts[0],
+			Name:  nameParts[1],
+			Host:  defaultHost,
+		}, nil
+	case 3:
+		return &GHRepo{
+			Owner: nameParts[1],
+			Name:  nameParts[2],
+			Host:  nameParts[0],
+		}, nil
+	default:
+		return nil, errors.New("invalid repository name")
+	}
+}

--- a/cmd/ghrepo_test.go
+++ b/cmd/ghrepo_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/nbio/st"
+)
+
+func TestNewGHRepo(t *testing.T) {
+	tests := []struct {
+		name         string
+		wantName     string
+		wantOwner    string
+		wantHost     string
+		wantFullName string
+		wantErr      bool
+		errMsg       string
+	}{
+		{
+			name:      "foo/bar",
+			wantOwner: "foo",
+			wantName:  "bar",
+			wantHost:  "github.com",
+			wantErr:   false,
+		}, {
+			name:      "other-github.com/foo/bar",
+			wantOwner: "foo",
+			wantName:  "bar",
+			wantHost:  "other-github.com",
+			wantErr:   false,
+		}, {
+			name:    "bar",
+			wantErr: true,
+			errMsg:  "invalid repository name",
+		}, {
+			name:    "",
+			wantErr: true,
+			errMsg:  "invalid repository name",
+		}}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ghr, err := newGHRepo(tt.name)
+
+			if tt.wantErr {
+				st.Assert(t, err.Error(), tt.errMsg)
+
+			} else {
+				st.Assert(t, err, nil)
+				st.Assert(t, ghr.Owner, tt.wantOwner)
+				st.Assert(t, ghr.Name, tt.wantName)
+				st.Assert(t, ghr.Host, tt.wantHost)
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -114,7 +114,7 @@ func init() {
 		defaultRepo = fmt.Sprintf("%s/%s", currentRepo.Owner(), currentRepo.Name())
 	}
 
-	RootCmd.Flags().StringP("repo", "r", defaultRepo, "target repository in '[HOST/]OWNER/REPO' format (defaults to the current working directory's repository)")
+	RootCmd.Flags().StringP("repo", "R", defaultRepo, "target repository in '[HOST/]OWNER/REPO' format (defaults to the current working directory's repository)")
 
 	today := time.Now().UTC()
 	defaultStart = today.AddDate(0, 0, -DefaultDaysBack).Format(DefaultDateFormat)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -42,7 +42,10 @@ func execute(t *testing.T, args string) string {
 func Test_RootCmd_NoArgs(t *testing.T) {
 	defer gock.Off()
 
-	currentRepo, _ := gh.CurrentRepository()
+	currentRepo, err := gh.CurrentRepository()
+	if err != nil {
+		t.Error(err)
+	}
 
 	gock.New("https://api.github.com/graphql").
 		Post("/").

--- a/cmd/suite_test.go
+++ b/cmd/suite_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"gopkg.in/h2non/gock.v1"
+)
+
+const (
+	ResponseJSON = `
+{
+    "data": {
+        "search": {
+            "pageInfo": {
+                "hasNextPage": false,
+                "endCursor": "Y3Vyc29yOjI="
+            },
+            "nodes": [
+                {
+                    "author": {
+                        "login": "Batman"
+                    },
+                    "additions": 6,
+                    "deletions": 3,
+                    "number": 5339,
+                    "createdAt": "2022-03-21T15:11:09Z",
+                    "changedFiles": 1,
+                    "isDraft": false,
+                    "mergedAt": "2022-03-21T16:22:05Z",
+                    "participants": {
+                        "totalCount": 3
+                    },
+                    "comments": {
+                        "totalCount": 0
+                    },
+                    "reviews": {
+                        "nodes": [
+                            {
+                                "author": {
+                                    "login": "Joker"
+                                },
+                                "createdAt": "2022-03-21T15:12:52Z",
+                                "state": "COMMENTED"
+                            },
+                            {
+                                "author": {
+                                    "login": "Joker"
+                                },
+                                "createdAt": "2022-03-22T15:12:52Z",
+                                "state": "APPROVED"
+                            }
+                        ]
+                    },
+                    "commits": {
+                        "totalCount": 1,
+                        "nodes": [
+                            {
+                                "commit": {
+                                    "committedDate": "2022-03-21T15:09:52Z"
+                                }
+                            }
+                        ]
+                    },
+                    "timelineItems": {
+                        "totalCount": 1,
+                        "nodes": [
+                            {
+                                "createdAt": "2022-03-15T03:46:20Z"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "author": {
+                        "login": "Batman"
+                    },
+                    "additions": 12,
+                    "deletions": 6,
+                    "number": 5340,
+                    "createdAt": "2022-03-22T15:11:09Z",
+                    "changedFiles": 2,
+                    "isDraft": false,
+                    "mergedAt": "2022-03-22T16:22:05Z",
+                    "participants": {
+                        "totalCount": 3
+                    },
+                    "comments": {
+                        "totalCount": 0
+                    },
+                    "reviews": {
+                        "nodes": [
+                            {
+                                "author": {
+                                    "login": "Joker"
+                                },
+                                "createdAt": "2022-03-22T15:12:52Z",
+                                "state": "COMMENTED"
+                            },
+                            {
+                                "author": {
+                                    "login": "Joker"
+                                },
+                                "createdAt": "2022-03-23T15:12:52Z",
+                                "state": "APPROVED"
+                            }
+                        ]
+                    },
+                    "commits": {
+                        "totalCount": 1,
+                        "nodes": [
+                            {
+                                "commit": {
+                                    "committedDate": "2022-03-22T15:09:52Z"
+                                }
+                            }
+                        ]
+                    },
+                    "timelineItems": {
+                        "totalCount": 1,
+                        "nodes": [
+                            {
+                                "createdAt": "2022-03-16T03:46:20Z"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}`
+)
+
+type GQLRequest struct {
+	Variables struct {
+		Query string
+	}
+}
+
+func gqlSearchQueryMatcher(owner, repo, start, end string) func(req *http.Request, ereq *gock.Request) (bool, error) {
+	return func(req *http.Request, ereq *gock.Request) (bool, error) {
+		var gqlRequest GQLRequest
+
+		var body, err = io.ReadAll(req.Body)
+		err = json.Unmarshal(body, &gqlRequest)
+
+		return gqlRequest.Variables.Query == fmt.Sprintf("repo:%s/%s type:pr merged:%s..%s",
+			owner,
+			repo,
+			start,
+			end), err
+	}
+}

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -23,6 +23,7 @@ const (
 )
 
 type UI struct {
+	Host       string
 	Owner      string
 	Repository string
 	StartDate  string
@@ -173,6 +174,7 @@ func (ui *UI) PrintMetrics() string {
 func (ui *UI) printMetricsImpl(defaultResultCount int) string {
 	client, err := gh.GQLClient(
 		&api.ClientOptions{
+			Host:        ui.Host,
 			EnableCache: true,
 			CacheTTL:    15 * time.Minute,
 			Timeout:     5 * time.Second,

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -20,148 +20,7 @@ const (
 	StartDate  = "2022-03-18"
 	EndDate    = "2022-03-28"
 	Query      = "author:Batman"
-
-	ResponseJSON = `
-{
-    "data": {
-        "search": {
-            "pageInfo": {
-                "hasNextPage": false,
-                "endCursor": "Y3Vyc29yOjI="
-            },
-            "nodes": [
-                {
-                    "author": {
-                        "login": "Batman"
-                    },
-                    "additions": 6,
-                    "deletions": 3,
-                    "number": 5339,
-                    "createdAt": "2022-03-21T15:11:09Z",
-                    "changedFiles": 1,
-                    "isDraft": false,
-                    "mergedAt": "2022-03-21T16:22:05Z",
-                    "participants": {
-                        "totalCount": 3
-                    },
-                    "comments": {
-                        "totalCount": 0
-                    },
-                    "reviews": {
-                        "nodes": [
-                            {
-                                "author": {
-                                    "login": "Joker"
-                                },
-                                "createdAt": "2022-03-21T15:12:52Z",
-                                "state": "COMMENTED"
-                            },
-                            {
-                                "author": {
-                                    "login": "Joker"
-                                },
-                                "createdAt": "2022-03-22T15:12:52Z",
-                                "state": "APPROVED"
-                            }
-                        ]
-                    },
-                    "commits": {
-                        "totalCount": 1,
-                        "nodes": [
-                            {
-                                "commit": {
-                                    "committedDate": "2022-03-21T15:09:52Z"
-                                }
-                            }
-                        ]
-                    },
-                    "timelineItems": {
-                        "totalCount": 1,
-                        "nodes": [
-                            {
-                                "createdAt": "2022-03-15T03:46:20Z"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "author": {
-                        "login": "Batman"
-                    },
-                    "additions": 12,
-                    "deletions": 6,
-                    "number": 5340,
-                    "createdAt": "2022-03-22T15:11:09Z",
-                    "changedFiles": 2,
-                    "isDraft": false,
-                    "mergedAt": "2022-03-22T16:22:05Z",
-                    "participants": {
-                        "totalCount": 3
-                    },
-                    "comments": {
-                        "totalCount": 0
-                    },
-                    "reviews": {
-                        "nodes": [
-                            {
-                                "author": {
-                                    "login": "Joker"
-                                },
-                                "createdAt": "2022-03-22T15:12:52Z",
-                                "state": "COMMENTED"
-                            },
-                            {
-                                "author": {
-                                    "login": "Joker"
-                                },
-                                "createdAt": "2022-03-23T15:12:52Z",
-                                "state": "APPROVED"
-                            }
-                        ]
-                    },
-                    "commits": {
-                        "totalCount": 1,
-                        "nodes": [
-                            {
-                                "commit": {
-                                    "committedDate": "2022-03-22T15:09:52Z"
-                                }
-                            }
-                        ]
-                    },
-                    "timelineItems": {
-                        "totalCount": 1,
-                        "nodes": [
-                            {
-                                "createdAt": "2022-03-16T03:46:20Z"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    }
-}`
 )
-
-type GQLRequest struct {
-	Variables struct {
-		Query string
-	}
-}
-
-func gqlSearchQueryMatcher(req *http.Request, ereq *gock.Request) (bool, error) {
-	var gqlRequest GQLRequest
-
-	var body, err = io.ReadAll(req.Body)
-	err = json.Unmarshal(body, &gqlRequest)
-
-	return gqlRequest.Variables.Query == fmt.Sprintf("repo:%s/%s type:pr merged:%s..%s",
-		Owner,
-		Repository,
-		StartDate,
-		EndDate), err
-}
 
 func gqlSearchQueryWithFilterMatcher(req *http.Request, ereq *gock.Request) (bool, error) {
 	var gqlRequest GQLRequest
@@ -183,7 +42,7 @@ func Test_SearchQuery(t *testing.T) {
 	gock.New("https://api.github.com/graphql").
 		Post("/").
 		MatchType("json").
-		AddMatcher(gqlSearchQueryMatcher).
+		AddMatcher(gqlSearchQueryMatcher(Owner, Repository, StartDate, EndDate)).
 		Reply(200).
 		BodyString(ResponseJSON)
 
@@ -208,7 +67,7 @@ func Test_SearchQuery_WithCSV(t *testing.T) {
 	gock.New("https://api.github.com/graphql").
 		Post("/").
 		MatchType("json").
-		AddMatcher(gqlSearchQueryMatcher).
+		AddMatcher(gqlSearchQueryMatcher(Owner, Repository, StartDate, EndDate)).
 		Reply(200).
 		BodyString(ResponseJSON)
 
@@ -239,14 +98,14 @@ func Test_SearchQuery_WithPagination(t *testing.T) {
 	gock.New("https://api.github.com/graphql").
 		Post("/").
 		MatchType("json").
-		AddMatcher(gqlSearchQueryMatcher).
+		AddMatcher(gqlSearchQueryMatcher(Owner, Repository, StartDate, EndDate)).
 		Reply(200).
 		BodyString(responseJSONWithPagination)
 
 	gock.New("https://api.github.com/graphql").
 		Post("/").
 		MatchType("json").
-		AddMatcher(gqlSearchQueryMatcher).
+		AddMatcher(gqlSearchQueryMatcher(Owner, Repository, StartDate, EndDate)).
 		Reply(200).
 		BodyString(ResponseJSON)
 


### PR DESCRIPTION
👋 Hi @hectcastro - Thanks for your work on `gh-metrics`! This PR seeks to pitch you on an idea for a consolidated, optional `--repo` flag to replace the required `--owner`/`--repo` flags. Admittedly, though, the effort spun out a bit and required I layer in a bit of complexity, particularly surrounding testability. So, I'm not at all offended if you'd prefer not to merge this...I figured I'd at least pitch ya on the idea, though 😄 

## Summary

This seeks to replace the previously-required `--owner`/`--repo` flags with a single, _optional_ `--repo` flag, whose value may be a `[HOST/]OWNER/REPO` string, where the `HOST/` part is optional, similar to the core `gh` CLI's `--repo` option (see `gh pr ls --help` for an example). In turn, this paves a path towards...

* allowing `--repo` to be optional (if not specified, its value is automatically set to the value of the repo in the current working directory, similar to how core `gh` commands set the value)
* enabling support for GitHub Enterprise instances hosted at non `github.com` URLs

As a bonus, this also ensures the command output is printed to whatever is set via `RootCmd.SetOut`, whereas previously the non-erroring command output was indiscriminately sent to `fmt.Println`, out of view of tests. Now, tests can invoke `RootCmd.SetOut` and successfully make assertions on the resulting output.

## Downsides

* This introduces a breaking change for users who assume distinct and required `--repo` and `--owner` flags
* This introduces a bit of complexity you feel may not be worth it (more code, more logic, some new global `defaultStart` and `defaultEnd` variables to assist with testing, etc.)

~Also note that while this seeks to make `gh-metrics`'s `--repo` option behave more like `gh`'s own `--repo` option, `gh-metrics` still uses a `-r` short flag whereas core `gh` uses a `-R`. Perhaps that could/should change too?~ Update: `gh-metrics` now uses the `-R` shorthand too.