### PR TITLE
ci: dynamically detect Go version from go.mod

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version-file: go.mod
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version-file: go.mod
 
       - uses: goreleaser/goreleaser-action@v4
         with:


### PR DESCRIPTION
@hectcastro - Do you feel this is a worthwhile change? I discovered the potential for this lil' optimization while poking around hacking on PR #54.

## Summary

`actions/setup-go@v3` supports the ability to dynamically detect the desired Go version from a `go.mod` file. In doing so, this tasks `go.mod` in being the single source of truth for the desired Go version, eliminating the need to hard-code this value in GH Actions YAML.

For more info:
https://github.com/actions/setup-go/tree/v3#getting-go-version-from-the-gomod-file