### PR TITLE
chore: update go version to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hectcastro/gh-metrics
 
-go 1.22
+go 1.24
 
 require (
 	github.com/cli/go-gh v1.2.1


### PR DESCRIPTION
## Summary
- update `go.mod` to use Go 1.24

## Testing
- `make fmtcheck`
- `GH_TOKEN=dummytoken go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6856b638b3d4832fb09a68ded4495d54