### PR TITLE
ci: add cooldown periods to dependabot update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

Adds Dependabot cooldown periods matching the dashboard configuration from `05166524bcdb0ba48a29d1de7f223693f0f4cac4`.

## Details

- Adds a 7 day default cooldown to all update entries.
- Adds semver-specific cooldowns for dependency ecosystems: 30 days for major updates, 7 days for minor updates, and 3 days for patch updates.
- Leaves the existing ecosystems, directories, and schedule intervals unchanged.

## Validation

- Verified the resulting YAML shape against the reference dashboard change.