### PR TITLE
fix: handle inconsistent graphQL response data

### DIFF
--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -71,11 +71,16 @@ func excelCompatDuration(d time.Duration) string {
 // marked ready for review, or its created date (if it was never in
 // a draft state).
 func getReadyForReviewOrPrCreatedAt(prCreated string, timelineItems TimelineItems) string {
-	if timelineItems.TotalCount == 0 {
+	if len(timelineItems.Nodes) == 0 {
 		return prCreated
 	}
 
-	return timelineItems.Nodes[0].ReadyForReviewEvent.CreatedAt
+	readyAt := timelineItems.Nodes[0].ReadyForReviewEvent.CreatedAt
+	if readyAt == "" {
+		return prCreated
+	}
+
+	return readyAt
 }
 
 // getTimeToFirstReview returns the time to first review, in hours and

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -207,6 +207,13 @@ func Test_getReadyForReviewOrPrCreatedAt_prCreatedAt(t *testing.T) {
 	}) == "2022-03-21T15:11:09Z", true)
 }
 
+func Test_getReadyForReviewOrPrCreatedAt_handlesInconsistentData(t *testing.T) {
+	st.Assert(t, getReadyForReviewOrPrCreatedAt("2022-03-21T15:11:09Z", TimelineItems{
+		TotalCount: 1,
+		Nodes:      TimelineItemNodes{},
+	}) == "2022-03-21T15:11:09Z", true)
+}
+
 func Test_getReadyForReviewOrPrCreatedAt_readyForReviewAt(t *testing.T) {
 	st.Assert(t, getReadyForReviewOrPrCreatedAt("2022-03-21T15:11:09Z", TimelineItems{
 		TotalCount: 1,

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -214,6 +214,15 @@ func Test_getReadyForReviewOrPrCreatedAt_handlesInconsistentData(t *testing.T) {
 	}) == "2022-03-21T15:11:09Z", true)
 }
 
+func Test_getReadyForReviewOrPrCreatedAt_emptyReadyAt(t *testing.T) {
+	st.Assert(t, getReadyForReviewOrPrCreatedAt("2022-03-21T15:11:09Z", TimelineItems{
+		TotalCount: 1,
+		Nodes: TimelineItemNodes{
+			{ReadyForReviewEvent{CreatedAt: ""}},
+		},
+	}) == "2022-03-21T15:11:09Z", true)
+}
+
 func Test_getReadyForReviewOrPrCreatedAt_readyForReviewAt(t *testing.T) {
 	st.Assert(t, getReadyForReviewOrPrCreatedAt("2022-03-21T15:11:09Z", TimelineItems{
 		TotalCount: 1,


### PR DESCRIPTION
## The problem
A bug was identified while attempting to use the extension in a private repo and received the following panic.

```bash
# command with output
./gh-metrics --repo <my-private-repo-gh-path> --query "author:gr3at" --start 2026-01-01 --end 2026-06-01

panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/hectcastro/gh-metrics/cmd.getReadyForReviewOrPrCreatedAt({0x1400001a210?, 0x1033bf960?}, {0xa, {0x1030a0780, 0x0, 0x0}})
# rest of panic dump
```

Checking locally, the problem was that it was possible (somehow) to have a `TotalCount` of value 10 and zero len `Nodes` which is inconsistent and unexpected.

## The solution (handling)

Shift the safety check in `getReadyForReviewOrPrCreatedAt` to the actual accessed `Nodes` slice, to prevent panic.
After the change i was able to run the extension without errors